### PR TITLE
CI: Don't treat phpdoc types as certain for phpstan 

### DIFF
--- a/tests/phpstan.neon.dist
+++ b/tests/phpstan.neon.dist
@@ -3,6 +3,7 @@
 
 parameters:
     level: 10
+    treatPhpDocTypesAsCertain: false
     paths:
         - ../src
     bootstrapFiles:


### PR DESCRIPTION
This fixes a phpstan error about the instanceof check for AnalyticsDetailLevels to always be true. We can't know this in the code, because they are stored in an array, and it's conceivable that wrong values could enter here.